### PR TITLE
feat: support react@16

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,15 @@
     "octicons": "^3.1.0"
   },
   "peerDependencies": {
-    "react": ">=0.13.0"
+    "react": ">=0.13.0",
+    "proptypes": "^1.1.0"
   },
   "devDependencies": {
     "eslint-config-jonnybuchanan": "^2.0.1",
     "nwb": "~0.2.0",
     "react": "^0.14.3",
     "react-addons-test-utils": "^0.14.3",
-    "react-dom": "^0.14.3"
+    "react-dom": "^0.14.3",
+    "proptypes": "^1.1.0"
   }
 }

--- a/src/Octicon.js
+++ b/src/Octicon.js
@@ -1,6 +1,7 @@
 require('../css/Octicon.css')
 
-import React, {PropTypes} from 'react'
+import React from 'react'
+import PropTypes from 'proptypes'
 
 let Octicon = React.createClass({
   propTypes: {


### PR DESCRIPTION
in react@16, proptypes have stand alone a npm package

can not import proptypes at react package anymore

